### PR TITLE
Adding valves handling to host section

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,7 +104,7 @@ tomcat_instance:
     #          url: jdbc:HypersonicSQL:database
     #          maxTotal: 8
     #          maxIdle: 4
-
+    valves: {}
 
   - instance_name: 'tomcat_app_sys2'
     short_system_name: 'T2'
@@ -161,6 +161,7 @@ tomcat_instance:
     tomcat_engine_name: Catalina
     tomcat_host_name: localhost
     contextes: {}
+    valves: {}
 
 tomcat_native_library_enable: false
 

--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -159,6 +159,10 @@
                prefix="{{ item.1.instance_name }}_access" suffix="{{ tomcat_access_log_extension }}" renameOnRotate="true"
                pattern="{{ tomcat_access_log_pattern }}" />
 
+{% for key in item.1.valves.keys() %}
+        <Valve className="{{ key }}"{% if item.1.valves[key] %}{% for valve_attr_key in item.1.valves[key].keys() %} {{ valve_attr_key }}="{{ item.1.valves[key][valve_attr_key] }}"{% endfor %} {% endif %}/>
+        
+{% endfor %}
       </Host>
     </Engine>
   </Service>


### PR DESCRIPTION
I needed to add a `RemoteIpValve` in my instance server.xml, so I patched your Jinga2 template to handle vars like this:

`        ...`
`        valves:`
`          org.apache.catalina.valves.RemoteIpValve:`
`            protocolHeader: x-forwarded-proto`

The first dictionary key is used as valve class name, the embedded dict is used to create valve's parameters (key=param name and value, well, param value ;), so that snippet produces this XML:

`        <Valve className="org.apache.catalina.valves.RemoteIpValve" protocolHeader="x-forwarded-proto" />`