### PR TITLE
Adding context managing

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -90,6 +90,9 @@ tomcat_instance:
     tomcat_java_permsize_max: 384
     # Java thread stack size in kilobytes (k)
     tomcat_java_thread_stack_size: 512
+    tomcat_engine_name: Catalina
+    tomcat_host_name: localhost
+    contextes: {}
 
   - instance_name: 'tomcat_app_sys2'
     short_system_name: 'T2'
@@ -143,6 +146,9 @@ tomcat_instance:
     tomcat_java_permsize_max: 384
     # Java thread stack size in kilobytes (k)
     tomcat_java_thread_stack_size: 512
+    tomcat_engine_name: Catalina
+    tomcat_host_name: localhost
+    contextes: {}
 
 tomcat_native_library_enable: false
 

--- a/tasks/prepare-catalina-base.yml
+++ b/tasks/prepare-catalina-base.yml
@@ -162,3 +162,12 @@
   with_nested:
     - [ 'context.xml', 'server.xml', 'web.xml', 'logging.properties', 'tomcat-users.xml' ]
     - "{{ tomcat_instance }}"
+
+- name: 'generate webapp specific configuartion from template'
+  template:
+    src: 'webapp-context.xml.j2'
+    dest: "{{ tomcat_system_home }}{{ item[0].instance_name }}/conf/{{ item[0].tomcat_engine_name|default('Catalina') }}/{{ item[0].tomcat_host_name|default('localhost') }}/{{ (item[1]|dict2items)[0].key }}.xml"
+    owner: "{{ tomcat_system_user }}"
+    group: "{{ tomcat_system_group }}"
+    mode: '0640'
+  loop: "{{ tomcat_instance | subelements('contextes') }}"

--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -111,7 +111,7 @@
     <!-- You should set jvmRoute to support load-balancing via AJP ie :
     <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
     -->
-    <Engine name="Catalina" defaultHost="localhost">
+    <Engine name="{{ item.1.tomcat_engine_name|default('Catalina') }}" defaultHost="localhost">
 
       <!--For clustering, please take a look at documentation at:
           /docs/cluster-howto.html  (simple how to)
@@ -146,7 +146,7 @@
         </Realm>
       </Realm>
 
-      <Host name="localhost"  appBase="webapps"
+      <Host name="{{ item.1.tomcat_host_name|default('localhost') }}"  appBase="webapps"
             unpackWARs="true" autoDeploy="true">
 
         <!-- SingleSignOn valve, share authentication between web applications

--- a/templates/webapp-context.xml.j2
+++ b/templates/webapp-context.xml.j2
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- {{ ansible_managed }} -->
+<!-- The contents of this file will be loaded for each web application -->
+<Context useHttpOnly="{% if tomcat_session_http_only == True %}true{% else %}false{% endif %}" >
+  <WatchedResource>WEB-INF/web.xml</WatchedResource>
+  <WatchedResource>WEB-INF/tomcat-web.xml</WatchedResource>
+  <WatchedResource>${catalina.base}/conf/web.xml</WatchedResource>
+
+{% for key in (item[1]|dict2items)[0].value.resources.keys() %}
+  <Resource name="{{ key }}"{% if (item[1]|dict2items)[0].value.resources[key] %}{% for attr_key in (item[1]|dict2items)[0].value.resources[key].keys() %} {{ attr_key }}="{{ (item[1]|dict2items)[0].value.resources[key][attr_key] }}"{% endfor %} {% endif %}/>
+{% endfor %}
+
+</Context>


### PR DESCRIPTION
I needed to add webapps specific context (mainly for JNDI resources), so I added this feature.

Usage: put in your vars something like this:
```
        ...
        contextes:
        - geoserver1:
            resources:
              'jdbc/EmployeeDB':
                auth: Container
                type: javax.sql.DataSource
                username: dbusername
                password: dbpassword
                driverClassName: org.hsql.jdbcDriver
                url: jdbc:HypersonicSQL:database
                maxTotal: 8
                maxIdle: 4
```
it will produce a context file containing:
`  <Resource name="jdbc/EmployeeDB" auth="Container" type="javax.sql.DataSource" username="dbusername" password="dbpassword" driverClassName="org.hsql.jdbcDriver" url="jdbc:HypersonicSQL:database" maxTotal="8" maxIdle="4" />`